### PR TITLE
Pause the video when appState changes from 'active'

### DIFF
--- a/src/Video.js
+++ b/src/Video.js
@@ -175,7 +175,9 @@ export default class Video extends React.Component {
 
   handleAppStateChange = () => {
     this.toggleControls(0);
-    this.updateVideoProgress();
+    if(AppState.currentState !== 'active') {
+      this.togglePaused(true);
+    }
     clearTimeout(this.controlsTO);
     clearTimeout(this.bufferingTO);
     clearTimeout(this.bufferingTooLongTO);


### PR DESCRIPTION
This is just a request from myself. Obviously we don't have to implement this. I just think it's weird that the video keeps playing if we switch the app to the background... Unless there is a reason for this and it is intentional?