### PR TITLE
MA-191: fixes some small issues with lives

### DIFF
--- a/src/LiveTimer.tsx
+++ b/src/LiveTimer.tsx
@@ -68,7 +68,7 @@ const LiveTimer: FunctionComponent<ILiveTimer> = props => {
 
   useEffect(() => {
     const parsedStartTime = Math.ceil((new Date(startTime).getTime() - new Date().getTime()) / 1000);
-    const parsedEndTime = (new Date(endTime).getTime() - new Date().getTime()) / 1000;
+    const parsedEndTime = ((new Date(endTime).getTime() - new Date().getTime()) / 1000 ) + 15 * 60;
     if (!!parsedStartTime) {
       if (parsedStartTime >= 0) {
         updateStateTime(formatTimer(parsedStartTime));

--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -194,7 +194,7 @@ const Video = forwardRef<
       : content?.next_lesson && (content?.next_lesson.id || content?.next_lesson.mobile_app_url);
   const audioOnly = content?.type === 'play-along' && listening;
   const minsToStartValue = minsToStart(liveData?.live_event_start_time_in_timezone || '');
-  const showTimer = liveEnded || (!!liveData && minsToStartValue < 15 && minsToStartValue > 0);
+  const showTimer = liveEnded || (!!liveData && minsToStartValue > 0);
   const completionTime = 0.95 * content?.length_in_seconds;
   const timeToComplete = useRef<NodeJS.Timeout | undefined>();
   const heartbeatInterval = useRef<NodeJS.Timeout | undefined>();
@@ -1033,9 +1033,7 @@ const Video = forwardRef<
   const onStartLiveTimer = (): void => onStart?.();
 
   const onEndLiveTimer = (): void => {
-    webViewRef.current?.injectJavaScript(`(function() {
-        window.video.pause();
-      })()`);
+    webViewRef.current?.injectJavaScript(`player.pauseVideo(); true;`);
     setLiveEnded(true);
     onEnd?.();
   };

--- a/src/helper.ts
+++ b/src/helper.ts
@@ -46,9 +46,9 @@ export const formatTimer = (seconds: number): IFormattedTime => {
   const minutes = Math.floor((seconds % 3600) / 60);
   const remainingSeconds = seconds % 60;
 
-  const hDisplay = hours > 0 ? hours : "00";
-  const mDisplay = minutes > 0 ? minutes  : "00";
-  const sDisplay = remainingSeconds;
+  const hDisplay = hours < 10 ? `0${hours}` : hours;
+  const mDisplay = minutes < 10 ? `0${minutes}` : minutes;
+  const sDisplay = remainingSeconds < 10 ? `0${remainingSeconds}` : remainingSeconds;
 
   return {
     hours: `${hDisplay}`,


### PR DESCRIPTION
**LiveTimer blocking video immediately on live end.** 
* This was an issue in the past cause sometimes the lives would go longer than scheduled. We should let the video play for at least 15 minutes extra past the live end time. 

**Video would not pause on liveEnd**

**Timer formatted weird**