### PR TITLE
MA-250: MA - App crashes when trying to open "How to play" on Student Focus page

### DIFF
--- a/src/Video.tsx
+++ b/src/Video.tsx
@@ -640,7 +640,7 @@ const Video = forwardRef<
       if (
         Math.trunc(cTime.current) !== content?.length_in_seconds &&
         !(
-          content.type.includes('challenge') &&
+          content.type?.includes('challenge') &&
           (cTime.current / content.length_in_seconds) * 100 >= 98.5
         )
       ) {
@@ -958,7 +958,7 @@ const Video = forwardRef<
     ) {
       onEndVideo();
     } else if (
-      content.type.includes('challenge') &&
+      content.type?.includes('challenge') &&
       (currentTime / content.length_in_seconds) * 100 >= 98.5
     ) {
       onEndVideo(false);


### PR DESCRIPTION
## Jira Ticket id

- https://musora.atlassian.net/browse/MA-250?atlOrigin=eyJpIjoiNzUwMjIzOWIyNTU3NGY0NGJmNzM4YWIwMjBjZTdmY2MiLCJwIjoiaiJ9

## Description

- Trailers don't have content type, so the app is crashing when we're trying to read it
- When I first worked on this, Didier's video changes weren't merged yet so that's why I didn't catch it.

## Related Issue(s)

- 

## Screenshots (if applicable)

- 

## Additional Notes

-